### PR TITLE
added salmon-core as peer dependencies to enforce @defichain/* deps version consistency

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -1,11 +1,11 @@
 # Define individuals that are responsible for code in this repository.
 # More details are here: https://help.github.com/articles/about-codeowners/
 
-/.github/                                       @fuxingloh @monstrobishi
+/.github/                                       @fuxingloh @monstrobishi @joeldavidw
 
 /adapters/                                      @fuxingloh @monstrobishi @joeldavidw
 /packages/                                      @fuxingloh @monstrobishi @joeldavidw
 
-CONTRIBUTING.md                                 @fuxingloh @monstrobishi
-README.md                                       @fuxingloh @monstrobishi
+CONTRIBUTING.md                                 @fuxingloh @monstrobishi @joeldavidw
+README.md                                       @fuxingloh @monstrobishi @joeldavidw
 LICENSE                                         @fuxingloh

--- a/.github/workflows/release-publish.yml
+++ b/.github/workflows/release-publish.yml
@@ -29,7 +29,7 @@ jobs:
 
       - run: npm ci
       - run: npm run build
-      - run: npm run version ${{ steps.version.outputs.result }}
+      - run: npm run version:set ${{ steps.version.outputs.result }}
 
       - name: Publish
         run: |

--- a/adapters/package.json
+++ b/adapters/package.json
@@ -13,5 +13,8 @@
   },
   "dependencies": {
     "@defichain/salmon-fetch": "0.0.0"
+  },
+  "peerDependencies": {
+    "@defichain/salmon-core": "0.0.0"
   }
 }

--- a/lerna.json
+++ b/lerna.json
@@ -1,6 +1,7 @@
 {
   "version": "0.0.0",
   "packages": [
+    ".",
     "adapters",
     "packages/*"
   ]

--- a/lerna.json
+++ b/lerna.json
@@ -1,7 +1,6 @@
 {
   "version": "0.0.0",
   "packages": [
-    ".",
     "adapters",
     "packages/*"
   ]

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,10 +1,9 @@
 {
-  "name": "oracle-adapters",
+  "name": "@defich/oracle-adapters",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
-      "name": "oracle-adapters",
       "license": "MIT",
       "workspaces": [
         "./adapters",
@@ -34,6 +33,9 @@
       "license": "MIT",
       "dependencies": {
         "@defichain/salmon-fetch": "0.0.0"
+      },
+      "peerDependencies": {
+        "@defichain/salmon-core": "0.0.0"
       }
     },
     "node_modules/@babel/code-frame": {
@@ -829,6 +831,10 @@
     },
     "node_modules/@defichain/salmon": {
       "resolved": "packages/salmon",
+      "link": true
+    },
+    "node_modules/@defichain/salmon-core": {
+      "resolved": "packages/salmon-core",
       "link": true
     },
     "node_modules/@defichain/salmon-fetch": {
@@ -4843,6 +4849,11 @@
       "dependencies": {
         "clone": "^1.0.2"
       }
+    },
+    "node_modules/defichain": {
+      "version": "0.0.1",
+      "resolved": "https://registry.npmjs.org/defichain/-/defichain-0.0.1.tgz",
+      "integrity": "sha512-MJlF96SJMwBfCECe3Y8qC2oEeNQCLsMOOOCwSitB3pjUTb25chPwevrXcCnhL3h1ldQ2uZlRDRYblYKk9eF4mw=="
     },
     "node_modules/define-properties": {
       "version": "1.1.3",
@@ -12957,7 +12968,17 @@
         "@defichain/salmon-wallet": "0.0.0",
         "@defichain/whale-api-client": "0.11.4"
       },
-      "devDependencies": {}
+      "peerDependencies": {
+        "@defichain/salmon-core": "0.0.0"
+      }
+    },
+    "packages/salmon-core": {
+      "name": "@defichain/salmon-core",
+      "version": "0.0.0",
+      "license": "MIT",
+      "dependencies": {
+        "defichain": "0.0.1"
+      }
     },
     "packages/salmon-fetch": {
       "name": "@defichain/salmon-fetch",
@@ -12968,7 +12989,9 @@
         "abort-controller": "^3.0.0",
         "cross-fetch": "^3.1.4"
       },
-      "devDependencies": {}
+      "peerDependencies": {
+        "@defichain/salmon-core": "0.0.0"
+      }
     },
     "packages/salmon-filter": {
       "name": "@defichain/salmon-filter",
@@ -12979,7 +13002,9 @@
         "@defichain/salmon-fetch": "0.0.0",
         "@defichain/whale-api-client": "0.11.4"
       },
-      "devDependencies": {}
+      "peerDependencies": {
+        "@defichain/salmon-core": "0.0.0"
+      }
     },
     "packages/salmon-testing": {
       "name": "@defichain/salmon-testing",
@@ -12990,7 +13015,9 @@
         "@defichain/whale-api-client": "0.11.4",
         "testcontainers": "^7.21.0"
       },
-      "devDependencies": {}
+      "peerDependencies": {
+        "@defichain/salmon-core": "0.0.0"
+      }
     },
     "packages/salmon-wallet": {
       "name": "@defichain/salmon-wallet",
@@ -13007,7 +13034,9 @@
         "@defichain/whale-api-client": "0.11.4",
         "@defichain/whale-api-wallet": "0.11.4"
       },
-      "devDependencies": {}
+      "peerDependencies": {
+        "@defichain/salmon-core": "0.0.0"
+      }
     }
   },
   "dependencies": {
@@ -13652,6 +13681,12 @@
         "@defichain/salmon-filter": "0.0.0",
         "@defichain/salmon-wallet": "0.0.0",
         "@defichain/whale-api-client": "0.11.4"
+      }
+    },
+    "@defichain/salmon-core": {
+      "version": "file:packages/salmon-core",
+      "requires": {
+        "defichain": "0.0.1"
       }
     },
     "@defichain/salmon-fetch": {
@@ -16942,6 +16977,11 @@
       "requires": {
         "clone": "^1.0.2"
       }
+    },
+    "defichain": {
+      "version": "0.0.1",
+      "resolved": "https://registry.npmjs.org/defichain/-/defichain-0.0.1.tgz",
+      "integrity": "sha512-MJlF96SJMwBfCECe3Y8qC2oEeNQCLsMOOOCwSitB3pjUTb25chPwevrXcCnhL3h1ldQ2uZlRDRYblYKk9eF4mw=="
     },
     "define-properties": {
       "version": "1.1.3",

--- a/package.json
+++ b/package.json
@@ -1,5 +1,5 @@
 {
-  "name": "oracle-adapters",
+  "name": "@defich/oracle-adapters",
   "private": true,
   "license": "MIT",
   "workspaces": [
@@ -8,13 +8,12 @@
   ],
   "scripts": {
     "prepare": "husky install",
-    "build": "lerna run build",
-    "version": "lerna version $1 --yes --no-push --no-git-tag-version",
-    "publish": "lerna exec -- npm publish --tag latest --access public --exact",
+    "build": "lerna run --scope '@defichain/*' build",
+    "version:set": "lerna version $1 --yes --no-push --no-git-tag-version --exact",
+    "publish:latest": "lerna exec -- npm publish --tag latest --access public",
     "lint": "eslint . --fix",
     "test": "jest --maxWorkers=100%",
-    "test:ci": "jest --ci --coverage --forceExit --maxWorkers=4",
-    "all": "npm run clean && npm run build && npm run lint && npm run test"
+    "test:ci": "jest --ci --coverage --forceExit --maxWorkers=4"
   },
   "devDependencies": {
     "@defichain/jellyfish-testing": "0.47.0",

--- a/package.json
+++ b/package.json
@@ -8,7 +8,7 @@
   ],
   "scripts": {
     "prepare": "husky install",
-    "build": "lerna run --scope '@defichain/*' build",
+    "build": "lerna run build",
     "version:set": "lerna version $1 --yes --no-push --no-git-tag-version --exact",
     "publish:latest": "lerna exec -- npm publish --tag latest --access public",
     "lint": "eslint . --fix",

--- a/packages/salmon-core/README.md
+++ b/packages/salmon-core/README.md
@@ -1,0 +1,2 @@
+`@defichain/salmon-core` as the base package for Salmon Framework to enforce consistent use of `@defichain/*`
+dependencies across project.

--- a/packages/salmon-core/package.json
+++ b/packages/salmon-core/package.json
@@ -1,0 +1,14 @@
+{
+  "private": false,
+  "name": "@defichain/salmon-core",
+  "version": "0.0.0",
+  "repository": "DeFiCh/oracle-adapters",
+  "bugs": "https://github.com/DeFiCh/oracle-adapters/issues",
+  "license": "MIT",
+  "main": "dist/index.js",
+  "types": "dist/index.d.ts",
+  "files": [],
+  "dependencies": {
+    "defichain": "0.0.1"
+  }
+}

--- a/packages/salmon-fetch/package.json
+++ b/packages/salmon-fetch/package.json
@@ -18,6 +18,7 @@
     "abort-controller": "^3.0.0",
     "cross-fetch": "^3.1.4"
   },
-  "devDependencies": {
+  "peerDependencies": {
+    "@defichain/salmon-core": "0.0.0"
   }
 }

--- a/packages/salmon-filter/package.json
+++ b/packages/salmon-filter/package.json
@@ -18,6 +18,7 @@
     "@defichain/whale-api-client": "0.11.4",
     "@defichain/jellyfish-network": "0.47.0"
   },
-  "devDependencies": {
+  "peerDependencies": {
+    "@defichain/salmon-core": "0.0.0"
   }
 }

--- a/packages/salmon-testing/package.json
+++ b/packages/salmon-testing/package.json
@@ -18,6 +18,7 @@
     "@defichain/testcontainers": "0.47.0",
     "testcontainers": "^7.21.0"
   },
-  "devDependencies": {
+  "peerDependencies": {
+    "@defichain/salmon-core": "0.0.0"
   }
 }

--- a/packages/salmon-wallet/package.json
+++ b/packages/salmon-wallet/package.json
@@ -24,6 +24,7 @@
     "@defichain/jellyfish-wallet": "0.47.0",
     "@defichain/jellyfish-wallet-classic": "0.47.0"
   },
-  "devDependencies": {
+  "peerDependencies": {
+    "@defichain/salmon-core": "0.0.0"
   }
 }

--- a/packages/salmon/package.json
+++ b/packages/salmon/package.json
@@ -20,6 +20,7 @@
     "@defichain/whale-api-client": "0.11.4",
     "@defichain/jellyfish-network": "0.47.0"
   },
-  "devDependencies": {
+  "peerDependencies": {
+    "@defichain/salmon-core": "0.0.0"
   }
 }


### PR DESCRIPTION
#### What kind of PR is this?:
<!-- Use one of the following kinds:
/kind feature
/kind fix
/kind chore
/kind docs
/kind refactor
/kind dependencies
-->

/kind chore

#### What this PR does / why we need it:

- added `@defichain/salmon-core` as peer dependencies to enforce `@defichain/*` dependencies version consistency
- also fixed release-publish.yml