### PR TITLE
added script to find and replace salmon-core peerDependencies

### DIFF
--- a/.github/workflows/release-publish.yml
+++ b/.github/workflows/release-publish.yml
@@ -31,6 +31,10 @@ jobs:
       - run: npm run build
       - run: npm run version:set ${{ steps.version.outputs.result }}
 
+      - name: find and replace peerDependencies
+        run: |
+          find packages/*/package.json adapters/package.json -type f -exec sed -i '' 's#    "@defichain/salmon-core": "0.0.0"#    "@defichain/salmon-core": "${{ steps.version.outputs.result }}"#g' {} \;
+
       - name: Publish
         run: |
           npm config set //registry.npmjs.org/:_authToken=$NPM_AUTH_TOKEN

--- a/.github/workflows/release-publish.yml
+++ b/.github/workflows/release-publish.yml
@@ -31,7 +31,7 @@ jobs:
       - run: npm run build
       - run: npm run version:set ${{ steps.version.outputs.result }}
 
-      - name: find and replace peerDependencies
+      - name: find and replace peerDependencies # because lerna doesn't update peers deps
         run: |
           find packages/*/package.json adapters/package.json -type f -exec sed -i '' 's#    "@defichain/salmon-core": "0.0.0"#    "@defichain/salmon-core": "${{ steps.version.outputs.result }}"#g' {} \;
 

--- a/packages/salmon-filter/package.json
+++ b/packages/salmon-filter/package.json
@@ -14,9 +14,9 @@
     "build": "tsc -b ./tsconfig.build.json"
   },
   "dependencies": {
+    "@defichain/jellyfish-network": "0.47.0",
     "@defichain/salmon-fetch": "0.0.0",
-    "@defichain/whale-api-client": "0.11.4",
-    "@defichain/jellyfish-network": "0.47.0"
+    "@defichain/whale-api-client": "0.11.4"
   },
   "peerDependencies": {
     "@defichain/salmon-core": "0.0.0"

--- a/packages/salmon-testing/package.json
+++ b/packages/salmon-testing/package.json
@@ -14,8 +14,8 @@
     "build": "tsc -b ./tsconfig.build.json"
   },
   "dependencies": {
-    "@defichain/whale-api-client": "0.11.4",
     "@defichain/testcontainers": "0.47.0",
+    "@defichain/whale-api-client": "0.11.4",
     "testcontainers": "^7.21.0"
   },
   "peerDependencies": {

--- a/packages/salmon-wallet/package.json
+++ b/packages/salmon-wallet/package.json
@@ -14,15 +14,15 @@
     "build": "tsc -b ./tsconfig.build.json"
   },
   "dependencies": {
-    "@defichain/salmon-fetch": "0.0.0",
-    "@defichain/whale-api-wallet": "0.11.4",
-    "@defichain/whale-api-client": "0.11.4",
     "@defichain/jellyfish-crypto": "0.47.0",
     "@defichain/jellyfish-network": "0.47.0",
     "@defichain/jellyfish-transaction": "0.47.0",
     "@defichain/jellyfish-transaction-builder": "0.47.0",
     "@defichain/jellyfish-wallet": "0.47.0",
-    "@defichain/jellyfish-wallet-classic": "0.47.0"
+    "@defichain/jellyfish-wallet-classic": "0.47.0",
+    "@defichain/salmon-fetch": "0.0.0",
+    "@defichain/whale-api-client": "0.11.4",
+    "@defichain/whale-api-wallet": "0.11.4"
   },
   "peerDependencies": {
     "@defichain/salmon-core": "0.0.0"

--- a/packages/salmon/package.json
+++ b/packages/salmon/package.json
@@ -14,11 +14,11 @@
     "build": "tsc -b ./tsconfig.build.json"
   },
   "dependencies": {
+    "@defichain/jellyfish-network": "0.47.0",
     "@defichain/salmon-fetch": "0.0.0",
     "@defichain/salmon-filter": "0.0.0",
     "@defichain/salmon-wallet": "0.0.0",
-    "@defichain/whale-api-client": "0.11.4",
-    "@defichain/jellyfish-network": "0.47.0"
+    "@defichain/whale-api-client": "0.11.4"
   },
   "peerDependencies": {
     "@defichain/salmon-core": "0.0.0"


### PR DESCRIPTION
<!--  Thanks for sending a pull request! -->

#### What kind of PR is this?:
<!-- Use one of the following kinds:
/kind feature
/kind fix
/kind chore
/kind docs
/kind refactor
/kind dependencies
-->

/kind fix

#### What this PR does / why we need it:

In Lerna, `peerDependencies` is unmanaged and won't be updated. But from a library building perspective where all versions should be synced, a script has been added to find and replace `peerDependencies` before publishing.