### PR TITLE
feat(wallet): add getWIF to get PrivateKey of Wallet

### DIFF
--- a/packages/salmon-wallet/__tests__/SalmonWalletMnemonic.spec.ts
+++ b/packages/salmon-wallet/__tests__/SalmonWalletMnemonic.spec.ts
@@ -3,28 +3,37 @@ import { WhaleApiClient } from '@defichain/whale-api-client'
 import { WhaleWalletAccountProvider } from '@defichain/whale-api-wallet'
 import { SalmonWalletMnemonic } from '../src'
 
-let whaleApiClient: WhaleApiClient
-
-beforeEach(async () => {
-  whaleApiClient = new WhaleApiClient({
-    url: 'https://ocean.defichain.com',
-    version: 'v0',
-    network: 'regtest'
-  })
-})
-
-afterEach(async () => {
-})
+const ABANDON_WORDS = [
+  'abandon', 'abandon', 'abandon', 'abandon', 'abandon', 'abandon', 'abandon', 'abandon', 'abandon', 'abandon', 'abandon', 'abandon', 'abandon', 'abandon', 'abandon', 'abandon', 'abandon', 'abandon', 'abandon', 'abandon', 'abandon', 'abandon', 'abandon', 'abandon'
+]
 
 it('should generate addresses', async () => {
-  const accountProvider = new WhaleWalletAccountProvider(whaleApiClient, getNetwork('regtest'))
-
-  const words = [
-    'abandon', 'abandon', 'abandon', 'abandon', 'abandon', 'abandon', 'abandon', 'abandon', 'abandon', 'abandon', 'abandon', 'abandon', 'abandon', 'abandon', 'abandon', 'abandon', 'abandon', 'abandon', 'abandon', 'abandon', 'abandon', 'abandon', 'abandon', 'abandon'
-  ]
-  const wallet = new SalmonWalletMnemonic(words, getNetwork('regtest'), accountProvider)
+  const client = new WhaleApiClient({
+    url: 'https://ocean.defichain.com',
+    network: 'regtest'
+  })
+  const accountProvider = new WhaleWalletAccountProvider(client, getNetwork('regtest'))
+  const wallet = new SalmonWalletMnemonic(ABANDON_WORDS, getNetwork('regtest'), accountProvider)
 
   expect(await wallet.get(0).getAddress()).toStrictEqual('bcrt1q3pxq49dnf5mpkhq05g9mtqejahh25f9wt9utjc')
   expect(await wallet.get(1).getAddress()).toStrictEqual('bcrt1q8yk8vwwud0qf6jhc4kykfm4ep6twfekecy85cv')
   expect(await wallet.get(2).getAddress()).toStrictEqual('bcrt1qkwhwtlskl0uhresp2wwrx7jrqqxpxss65jrxx3')
+})
+
+it('should be able to get private key in WIF (regtest)', async () => {
+  const wallet = new SalmonWalletMnemonic(ABANDON_WORDS, getNetwork('regtest'))
+
+  expect(await wallet.getWIF(0)).toStrictEqual(await wallet.getWIF(0))
+  expect(await wallet.getWIF(0)).toStrictEqual('cSSzEEsyvfvEWgy3zQ3pEZfdY9kRVwnHd7jYuvZ5CXP1sUmzhdUv')
+  expect(await wallet.getWIF(1)).toStrictEqual('cPMw2NPvBnk46uQFrQ3NS4vgSh5S3UawUe1vo7DqcMSRRGxJTGDo')
+  expect(await wallet.getWIF(10000)).toStrictEqual('cQjx59Z5eqTvDWtTx7oYohLgby65BGoJkHFmPUtM7RuqG1nDVc2b')
+})
+
+it('should be able to get private key in WIF (mainnet)', async () => {
+  const wallet = new SalmonWalletMnemonic(ABANDON_WORDS, getNetwork('mainnet'))
+
+  expect(await wallet.getWIF(0)).toStrictEqual(await wallet.getWIF(0))
+  expect(await wallet.getWIF(0)).toStrictEqual('L25zmKt8VcDyMFVnbzEgsFAZuvT1qVgbZ5b5oW6ZhQj1cjeccjZQ')
+  expect(await wallet.getWIF(1)).toStrictEqual('KxzwZTQ4kj3nwTvzTzEF4kRcpTn2P2VFQbsTggmL7EnRAXsS79zX')
+  expect(await wallet.getWIF(12000)).toStrictEqual('L4Souhb352a2gnVXXWdPRMVQNBEdrTsigdeVjRLe6jzusN2GSngk')
 })

--- a/packages/salmon-wallet/src/SalmonWalletMnemonic.ts
+++ b/packages/salmon-wallet/src/SalmonWalletMnemonic.ts
@@ -1,7 +1,8 @@
 import { Network } from '@defichain/jellyfish-network'
-import { JellyfishWallet, WalletAccountProvider } from '@defichain/jellyfish-wallet'
+import { JellyfishWallet, WalletAccountProvider, WalletEllipticPair } from '@defichain/jellyfish-wallet'
 import { Bip32Options, MnemonicHdNode, MnemonicHdNodeProvider } from '@defichain/jellyfish-wallet-mnemonic'
 import { WhaleWalletAccount } from '@defichain/whale-api-wallet'
+import { WIF } from '@defichain/jellyfish-crypto'
 
 /**
  * Basic wrapper around JellyfishWallet, this uses a mnemonic phrase to initialise
@@ -9,8 +10,9 @@ import { WhaleWalletAccount } from '@defichain/whale-api-wallet'
  *
  * See: https://github.com/DeFiCh/jellyfish/tree/main/packages/jellyfish-wallet/src/wallet.ts
  */
-
 export class SalmonWalletMnemonic extends JellyfishWallet<WhaleWalletAccount, MnemonicHdNode> {
+  private readonly network: Network
+
   /**
    * @param {string[]} words to derive
    * @param {Network} network
@@ -19,14 +21,30 @@ export class SalmonWalletMnemonic extends JellyfishWallet<WhaleWalletAccount, Mn
   constructor (
     words: string[],
     network: Network,
-    accountProvider: WalletAccountProvider<WhaleWalletAccount>
+    accountProvider: WalletAccountProvider<WhaleWalletAccount> = new EmptyWalletAccountProvider()
   ) {
-    const hdNodeProvider = MnemonicHdNodeProvider.fromWords(words,
-      SalmonWalletMnemonic.getBip32Options(network))
-
+    const hdNodeProvider = SalmonWalletMnemonic.getMnemonicHdNodeProvider(words, network)
     const coinType: number = JellyfishWallet.COIN_TYPE_DFI
     const purpose: number = JellyfishWallet.PURPOSE_LIGHT_PRICE_ORACLE
     super(hdNodeProvider, accountProvider, coinType, purpose)
+    this.network = network
+  }
+
+  /**
+   * Get Private Key in Wallet Import Format (WIF) in SalmonWalletMnemonic.
+   *
+   * @param {number} account number to get
+   * @return {Promise<string>} PrivateKey in WIF
+   */
+  async getWIF (account: number): Promise<string> {
+    const node = this.deriveNode(account)
+    const privateKey = await node.privateKey()
+    return WIF.encode(this.network.wifPrefix, privateKey)
+  }
+
+  private static getMnemonicHdNodeProvider (words: string[], network: Network): MnemonicHdNodeProvider {
+    const options = SalmonWalletMnemonic.getBip32Options(network)
+    return MnemonicHdNodeProvider.fromWords(words, options)
   }
 
   private static getBip32Options (network: Network): Bip32Options {
@@ -37,5 +55,14 @@ export class SalmonWalletMnemonic extends JellyfishWallet<WhaleWalletAccount, Mn
       },
       wif: network.wifPrefix
     }
+  }
+}
+
+/**
+ * Default empty wallet account provider to perform session-less disconnected Wallet operations.
+ */
+class EmptyWalletAccountProvider implements WalletAccountProvider<WhaleWalletAccount> {
+  provide (_: WalletEllipticPair): WhaleWalletAccount {
+    throw new Error('You are using EmptyWalletAccountProvider which do not have access to WhaleApiClient.')
   }
 }


### PR DESCRIPTION
<!--  Thanks for sending a pull request! -->

#### What kind of PR is this?:
<!-- Use one of the following kinds:
/kind feature
/kind fix
/kind chore
/kind docs
/kind refactor
/kind dependencies
-->

/kind feature

Get Private Key in Wallet Import Format (WIF) in SalmonWalletMnemonic. This allows easy import of private key into `@defichain/jellyfish-wallet-classic` to use for oracle publish in Lambda environment.