### PR TITLE
feat(wallet): add getAddress to get address of Wallet without accessing a node

### DIFF
--- a/packages/salmon-wallet/__tests__/SalmonWalletMnemonic.spec.ts
+++ b/packages/salmon-wallet/__tests__/SalmonWalletMnemonic.spec.ts
@@ -20,6 +20,19 @@ it('should generate addresses', async () => {
   expect(await wallet.get(2).getAddress()).toStrictEqual('bcrt1qkwhwtlskl0uhresp2wwrx7jrqqxpxss65jrxx3')
 })
 
+it('should generate addresses without accessing a node', async () => {
+  const client = new WhaleApiClient({
+    url: 'https://ocean.defichain.com',
+    network: 'regtest'
+  })
+  const accountProvider = new WhaleWalletAccountProvider(client, getNetwork('regtest'))
+  const wallet = new SalmonWalletMnemonic(ABANDON_WORDS, getNetwork('regtest'), accountProvider)
+
+  expect(await wallet.getAddress(0)).toStrictEqual(await wallet.get(0).getAddress())
+  expect(await wallet.getAddress(1)).toStrictEqual(await wallet.get(1).getAddress())
+  expect(await wallet.getAddress(2)).toStrictEqual(await wallet.get(2).getAddress())
+})
+
 it('should be able to get private key in WIF (regtest)', async () => {
   const wallet = new SalmonWalletMnemonic(ABANDON_WORDS, getNetwork('regtest'))
 

--- a/packages/salmon-wallet/src/SalmonWalletMnemonic.ts
+++ b/packages/salmon-wallet/src/SalmonWalletMnemonic.ts
@@ -2,7 +2,7 @@ import { Network } from '@defichain/jellyfish-network'
 import { JellyfishWallet, WalletAccountProvider, WalletEllipticPair } from '@defichain/jellyfish-wallet'
 import { Bip32Options, MnemonicHdNode, MnemonicHdNodeProvider } from '@defichain/jellyfish-wallet-mnemonic'
 import { WhaleWalletAccount } from '@defichain/whale-api-wallet'
-import { WIF } from '@defichain/jellyfish-crypto'
+import { Bech32, WIF } from '@defichain/jellyfish-crypto'
 
 /**
  * Basic wrapper around JellyfishWallet, this uses a mnemonic phrase to initialise
@@ -40,6 +40,18 @@ export class SalmonWalletMnemonic extends JellyfishWallet<WhaleWalletAccount, Mn
     const node = this.deriveNode(account)
     const privateKey = await node.privateKey()
     return WIF.encode(this.network.wifPrefix, privateKey)
+  }
+
+  /**
+   * Get address with account number in SalmonWalletMnemonic.
+   *
+   * @param {number} account number to get
+   * @return {Promise<string>} address
+   */
+  async getAddress (account: number): Promise<string> {
+    const node = this.deriveNode(account)
+    const pubKey = await node.publicKey()
+    return Bech32.fromPubKey(pubKey, this.network.bech32.hrp, 0x00)
   }
 
   private static getMnemonicHdNodeProvider (words: string[], network: Network): MnemonicHdNodeProvider {


### PR DESCRIPTION
<!--  Thanks for sending a pull request! -->

#### What kind of PR is this?:
<!-- Use one of the following kinds:
/kind feature
/kind fix
/kind chore
/kind docs
/kind refactor
/kind dependencies
-->

/kind feature

#### What this PR does / why we need it:

Allows you to `getAddress(account: number)` of a SalmonWalletMnemonic without accessing a node.