### PR TITLE
Updated iexcloud to use ` /last` endpoint

### DIFF
--- a/adapters/__tests__/iexcloud.test.ts
+++ b/adapters/__tests__/iexcloud.test.ts
@@ -9,22 +9,14 @@ afterEach(() => {
 
 it('should fetch price from iexcloud', async () => {
   nock('https://cloud.iexapis.com')
-    .get('/stable/tops?symbols=FB&token=API_TOKEN')
+    .get('/stable/tops/last?symbols=FB&token=API_TOKEN')
     .reply(200, function (_) {
       return `[
           {
             "symbol": "FB",
-            "bidSize": 200,
-            "bidPrice": 120.8,
-            "askSize": 100,
-            "askPrice": 122.5,
-            "volume": 205208,
-            "lastSalePrice": 121.41,
-            "lastSaleSize": 100,
-            "lastSaleTime": 1480446908666,
-            "lastUpdated": 1480446923942,
-            "sector": "softwareservices",
-            "securityType": "commonstock"
+            "price": 121.41,
+            "size": 1,
+            "time": 1480446908666
           }
         ]`
     })
@@ -42,74 +34,50 @@ it('should fetch price from iexcloud', async () => {
 
 it('should fetch multiple prices from iexcloud', async () => {
   nock('https://cloud.iexapis.com')
-    .get('/stable/tops?symbols=TSLA,AAPL,FB&token=API_TOKEN')
+    .get('/stable/tops/last?symbols=FB,IBM,SNAP&token=API_TOKEN')
     .reply(200, function (_) {
       return `[
           {
-            "symbol":"TSLA",
-            "sector":"consumerdurables",
-            "securityType":"cs",
-            "bidPrice":0,
-            "bidSize":0,
-            "askPrice":0,
-            "askSize":0,
-            "lastUpdated":1623096987115,
-            "lastSalePrice":605.14,
-            "lastSaleSize":10,
-            "lastSaleTime":1623095998146,
-            "volume":480662
+            "symbol": "FB",
+            "price": 121.41,
+            "size": 1,
+            "time": 1480446908666
           },
           {
-            "symbol":"AAPL",
-            "sector":"electronictechnology",
-            "securityType":"cs",
-            "bidPrice":0,
-            "bidSize":0,
-            "askPrice":0,
-            "askSize":0,
-            "lastUpdated":1623099600004,
-            "lastSalePrice":126,
-            "lastSaleSize":100,
-            "lastSaleTime":1623097192802,
-            "volume":1401779
+            "symbol": "IBM",
+            "price": 128.89,
+            "size": 1,
+            "time": 1649188799102
           },
           {
-            "symbol":"FB",
-            "sector":"technologyservices",
-            "securityType":"cs",
-            "bidPrice":0,
-            "bidSize":0,
-            "askPrice":0,
-            "askSize":0,
-            "lastUpdated":1623097044336,
-            "lastSalePrice":336.59,
-            "lastSaleSize":15,
-            "lastSaleTime":1623095999551,
-            "volume":598873
+            "symbol": "SNAP",
+            "price": 38.26,
+            "size": 100,
+            "time": 1649188799978
           }
         ]`
     })
 
-  const prices = await iexcloud(['TSLA', 'AAPL', 'FB'], 'API_TOKEN')
+  const prices = await iexcloud(['FB', 'IBM', 'SNAP'], 'API_TOKEN')
 
   expect(prices).toStrictEqual([
     {
-      token: 'TSLA',
-      amount: new BigNumber(605.14),
-      currency: 'USD',
-      timestamp: new BigNumber(1623095998146)
-    },
-    {
-      token: 'AAPL',
-      amount: new BigNumber(126),
-      currency: 'USD',
-      timestamp: new BigNumber(1623097192802)
-    },
-    {
       token: 'FB',
-      amount: new BigNumber(336.59),
+      amount: new BigNumber(121.41),
       currency: 'USD',
-      timestamp: new BigNumber(1623095999551)
+      timestamp: new BigNumber(1480446908666)
+    },
+    {
+      token: 'IBM',
+      amount: new BigNumber(128.89),
+      currency: 'USD',
+      timestamp: new BigNumber(1649188799102)
+    },
+    {
+      token: 'SNAP',
+      amount: new BigNumber(38.26),
+      currency: 'USD',
+      timestamp: new BigNumber(1649188799978)
     }
   ])
 })

--- a/adapters/src/iexcloud.ts
+++ b/adapters/src/iexcloud.ts
@@ -1,6 +1,6 @@
 import { AssetPrice, fetchAsJson, newAssetPrice } from '@defichain/salmon-fetch'
 
-const URL = 'https://cloud.iexapis.com/stable/tops'
+const URL = 'https://cloud.iexapis.com/stable/tops/last'
 
 export default async function (symbols: string[], apiToken: string): Promise<AssetPrice[]> {
   const fetchPath = `${URL}?symbols=${symbols.join(',')}&token=${apiToken}`
@@ -9,6 +9,6 @@ export default async function (symbols: string[], apiToken: string): Promise<Ass
   })
 
   return response.data.map((x: any): AssetPrice => {
-    return newAssetPrice(x.symbol, x.lastSalePrice, 'USD', x.lastSaleTime)
+    return newAssetPrice(x.symbol, x.price, 'USD', x.time)
   })
 }


### PR DESCRIPTION
<!--  Thanks for sending a pull request! -->

#### What kind of PR is this?:
<!-- Use one of the following kinds:
/kind feature
/kind fix
/kind chore
/kind docs
/kind refactor
/kind dependencies
-->

/kind fix 

#### What this PR does / why we need it:
Previously `/tops` was used but it does not send the "last" sale price after the market closes. By using `/tops/last` instead the last price would always be sent. This would prevent the oracle from being considered "down" by the chain after the market closes.


#### Which issue(s) does this PR fixes?:
<!--
(Optional) Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
-->
Fixes #

#### Additional comments?:
