### PR TITLE
chore(workflows): cleanup workflow permissions and names

### DIFF
--- a/.github/workflows/defichain-dependencies.yml
+++ b/.github/workflows/defichain-dependencies.yml
@@ -27,7 +27,6 @@ jobs:
       - name: Create Pull Request
         uses: peter-evans/create-pull-request@bd72e1b7922d417764d27d30768117ad7da78a0e
         with:
-          token: ${{ secrets.DEFICHAIN_BOT_GITHUB_TOKEN }}
           labels: kind/dependencies
           committer: DeFiChain Bot <github-bot@defichain.com>
           author: DeFiChain Bot <github-bot@defichain.com>

--- a/.github/workflows/oss-governance-bot.yml
+++ b/.github/workflows/oss-governance-bot.yml
@@ -1,4 +1,4 @@
-name: Governance
+name: OSS Governance
 
 on:
   pull_request_target:
@@ -8,12 +8,15 @@ on:
   issue_comment:
     types: [ created ]
 
+permissions:
+  contents: read
+  issues: write
+  pull-requests: write
+  statuses: write
+  checks: write
+
 jobs:
-  main:
-    name: OSS
+  Bot:
     runs-on: ubuntu-latest
     steps:
-      - uses: DeFiCh/oss-governance-bot@99f1d488fe91acc397cdac556f3c6bd309f28460
-        with:
-          github-token: ${{ secrets.DEFICHAIN_BOT_GITHUB_TOKEN }}
-
+      - uses: BirthdayResearch/oss-governance-bot@23a023a59e633947923a299f0497371576e12e78

--- a/.github/workflows/oss-governance-labeler.yml
+++ b/.github/workflows/oss-governance-labeler.yml
@@ -1,15 +1,20 @@
-name: Governance
+name: OSS Governance
 
 on:
   pull_request_target:
-    types: [ synchronize, opened ]
+    types: [ opened, edited, synchronize ]
+
+permissions:
+  contents: read
+  issues: write
+  pull-requests: write
+  statuses: write
+  checks: write
 
 jobs:
-  labeler:
-    name: Labeler
+  Labeler:
     runs-on: ubuntu-latest
     steps:
       - uses: fuxingloh/multi-labeler@67208f475e36fc4f95e3d5a2d4e450433f288be8
         with:
-          github-token: ${{ secrets.DEFICHAIN_BOT_GITHUB_TOKEN }}
           config-path: .github/labeler.yml

--- a/.github/workflows/oss-governance-labels.yml
+++ b/.github/workflows/oss-governance-labels.yml
@@ -1,13 +1,16 @@
-name: Labels
+name: OSS Governance
 
 on:
   push:
     branches: [ main ]
     paths: [ .github/labels.yml ]
 
+permissions:
+  contents: read
+  issues: write
+
 jobs:
-  main:
-    name: Syncer
+  Labels:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@2541b1294d2704b0964813337f33b291d3f8596b

--- a/.github/workflows/release-drafter.yml
+++ b/.github/workflows/release-drafter.yml
@@ -4,6 +4,10 @@ on:
   push:
     branches: [ main ]
 
+permissions:
+  contents: write
+  pull-requests: read
+
 concurrency:
   group: ${{ github.workflow }}-${{ github.event_name }}-${{ github.ref }}
   cancel-in-progress: true


### PR DESCRIPTION
#### What kind of PR is this?:

/kind chore

#### What this PR does / why we need it:

- Rename workflows related to "OSS Governance" into a single Workflow, renamed the job within to "Labels", "Labeler" and "Bot".
- Add `permissions:` for workflows to harden workflow security.
- Remov the use of `DEFICHAIN_BOT_GITHUB_TOKEN` for security hardening.
- Add `concurrency:` for workflows that requires it.
- Bump versions and migrate "OSS Governance Bot" to use the new org.