### PR TITLE
chore(dependencies): move deps to inner packages

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -11,10 +11,7 @@
         "./packages/*"
       ],
       "devDependencies": {
-        "@defichain/jellyfish-testing": "2.67.2",
-        "@defichain/testcontainers": "2.67.2",
         "@types/jest": "27.5.2",
-        "defichain": "2.67.2",
         "eslint": "7.32.0",
         "eslint-config-standard-jsx": "10.0.0",
         "eslint-config-standard-with-typescript": "21.0.1",
@@ -23,7 +20,6 @@
         "lerna": "5.1.6",
         "lint-staged": "13.0.3",
         "nock": "13.2.9",
-        "rimraf": "3.0.2",
         "ts-jest": "27.1.5",
         "typescript": "4.2.4",
         "wait-for-expect": "3.0.2"
@@ -5989,6 +5985,7 @@
       "version": "2.67.2",
       "resolved": "https://registry.npmjs.org/defichain/-/defichain-2.67.2.tgz",
       "integrity": "sha512-z45HMcoattBKDE4yk3jFtk2B83SqcGFdiwT0gD8lTsnJELQ+RfBAHhHZZBCFVpT0lyqBMgGSsLVFHIhOWDiqkA==",
+      "peer": true,
       "engines": {
         "node": ">=v16.17.0"
       }
@@ -14212,7 +14209,14 @@
       "license": "MIT",
       "dependencies": {
         "@defichain/jellyfish-network": "^2.67.2",
+        "@defichain/salmon-fetch": "0.0.0",
+        "@defichain/salmon-filter": "0.0.0",
+        "@defichain/salmon-wallet": "0.0.0",
         "@defichain/whale-api-client": "^2.67.2"
+      },
+      "devDependencies": {
+        "@defichain/jellyfish-testing": "^2.67.2",
+        "@defichain/testcontainers": "^2.67.2"
       },
       "peerDependencies": {
         "@defichain/salmon-core": "0.0.0"
@@ -14951,6 +14955,11 @@
       "version": "file:packages/salmon",
       "requires": {
         "@defichain/jellyfish-network": "^2.67.2",
+        "@defichain/jellyfish-testing": "^2.67.2",
+        "@defichain/salmon-fetch": "0.0.0",
+        "@defichain/salmon-filter": "0.0.0",
+        "@defichain/salmon-wallet": "0.0.0",
+        "@defichain/testcontainers": "^2.67.2",
         "@defichain/whale-api-client": "^2.67.2"
       }
     },
@@ -18905,7 +18914,8 @@
     "defichain": {
       "version": "2.67.2",
       "resolved": "https://registry.npmjs.org/defichain/-/defichain-2.67.2.tgz",
-      "integrity": "sha512-z45HMcoattBKDE4yk3jFtk2B83SqcGFdiwT0gD8lTsnJELQ+RfBAHhHZZBCFVpT0lyqBMgGSsLVFHIhOWDiqkA=="
+      "integrity": "sha512-z45HMcoattBKDE4yk3jFtk2B83SqcGFdiwT0gD8lTsnJELQ+RfBAHhHZZBCFVpT0lyqBMgGSsLVFHIhOWDiqkA==",
+      "peer": true
     },
     "define-properties": {
       "version": "1.1.3",

--- a/package.json
+++ b/package.json
@@ -16,10 +16,7 @@
     "test:ci": "jest --ci --coverage --forceExit --maxWorkers=4"
   },
   "devDependencies": {
-    "@defichain/jellyfish-testing": "2.67.2",
-    "@defichain/testcontainers": "2.67.2",
     "@types/jest": "27.5.2",
-    "defichain": "2.67.2",
     "eslint": "7.32.0",
     "eslint-config-standard-jsx": "10.0.0",
     "eslint-config-standard-with-typescript": "21.0.1",
@@ -28,7 +25,6 @@
     "lerna": "5.1.6",
     "lint-staged": "13.0.3",
     "nock": "13.2.9",
-    "rimraf": "3.0.2",
     "ts-jest": "27.1.5",
     "typescript": "4.2.4",
     "wait-for-expect": "3.0.2"

--- a/packages/salmon/package.json
+++ b/packages/salmon/package.json
@@ -12,9 +12,7 @@
     "build": "tsc -b ./tsconfig.build.json"
   },
   "dependencies": {
-    "@defichain/jellyfish-testing": "^2.67.2",
     "@defichain/jellyfish-network": "^2.67.2",
-    "@defichain/testcontainers": "^2.67.2",
     "@defichain/salmon-fetch": "0.0.0",
     "@defichain/salmon-filter": "0.0.0",
     "@defichain/salmon-wallet": "0.0.0",
@@ -22,5 +20,9 @@
   },
   "peerDependencies": {
     "@defichain/salmon-core": "0.0.0"
+  },
+  "devDependencies": {
+    "@defichain/jellyfish-testing": "^2.47.1",
+    "@defichain/testcontainers": "^2.47.1"
   }
 }

--- a/packages/salmon/package.json
+++ b/packages/salmon/package.json
@@ -12,7 +12,9 @@
     "build": "tsc -b ./tsconfig.build.json"
   },
   "dependencies": {
+    "@defichain/jellyfish-testing": "^2.67.2",
     "@defichain/jellyfish-network": "^2.67.2",
+    "@defichain/testcontainers": "^2.67.2",
     "@defichain/salmon-fetch": "0.0.0",
     "@defichain/salmon-filter": "0.0.0",
     "@defichain/salmon-wallet": "0.0.0",

--- a/packages/salmon/package.json
+++ b/packages/salmon/package.json
@@ -22,7 +22,7 @@
     "@defichain/salmon-core": "0.0.0"
   },
   "devDependencies": {
-    "@defichain/jellyfish-testing": "^2.47.1",
-    "@defichain/testcontainers": "^2.47.1"
+    "@defichain/jellyfish-testing": "^2.67.2",
+    "@defichain/testcontainers": "^2.67.2"
   }
 }


### PR DESCRIPTION
<!--  Thanks for sending a pull request! -->

#### What this PR does / why we need it:

`@defichain/*` isn't used at the root; no point the declaring it there. Let's move to the inner package.