### PR TITLE
chore(renovate): update range strategy to bump

### DIFF
--- a/.github/renovate.json
+++ b/.github/renovate.json
@@ -10,6 +10,7 @@
   "major": {
     "dependencyDashboardApproval": true
   },
+  "rangeStrategy": "bump",
   "packageRules": [
     {
       "matchManagers": ["github-actions"],


### PR DESCRIPTION
<!--  Thanks for sending a pull request! -->

#### What this PR does / why we need it:

Configure `renovate.json` - `rangeStrategy` to bump; to keep dependencies presentation on `package.json` obvious and accurate.
